### PR TITLE
test: Fix type inference failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,4 @@ jobs:
       - run: rustup show
       - uses: Swatinem/rust-cache@v2
       - name: Test
-        run: cargo test
+        run: cargo test --all

--- a/derive/tests/fixed_bytes.rs
+++ b/derive/tests/fixed_bytes.rs
@@ -39,11 +39,11 @@ macro_rules! test_derive_traits {
 		assert_eq!(s, s2);
 
 		// AsRef
-		assert_eq!(s.as_ref(), &a[..]);
+		assert_eq!(s.as_ref() as &[u8], &a[..]);
 
 		// AsMut
 		let mut s2 = s.clone();
-		s2.as_mut()[2] = 2;
+		(s2.as_mut() as &mut [u8])[2] = 2;
 		assert_eq!(s2, $x::from([1, 2, 2, 4]));
 
 		// Clone


### PR DESCRIPTION
The `FixedBytes` derive macro originally implemented only `AsRef<[u8]>` and `AsMut<[u8]>`, but the implementation of`AsRef<[u8; N]>` and `AsMut<[u8; N]>` were added later, causing type inference ambiguities when calling their methods.

This PR resolves the test failure by addressing the ambiguity in `AsRef` and `AsMut` usage.