### PR TITLE
feat: Enable derive feature by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/buidl"
 buidl-derive = { version = "0.1", path = "derive", optional = true }
 
 [features]
-default = ["std"]
+default = ["std", "derive"]
 derive = ["buidl-derive"]
 std = []
 


### PR DESCRIPTION
This PR enables `derive` feature for `buidl` by default.