### PR TITLE
feat: Add DerefMut impl to FixedBytes derive macro

### DIFF
--- a/derive/src/fixed_bytes.rs
+++ b/derive/src/fixed_bytes.rs
@@ -103,18 +103,6 @@ pub fn expand_fixed_bytes(input: DeriveInput) -> TokenStream {
 			}
 		}
 
-		impl #impl_generics AsRef<#inner> for #ty #ty_generics #where_clause {
-			fn as_ref(&self) -> &#inner {
-				&self.#data
-			}
-		}
-
-		impl #impl_generics AsMut<#inner> for #ty #ty_generics #where_clause {
-			fn as_mut(&mut self) -> &mut #inner {
-				&mut self.#data
-			}
-		}
-
 		impl #impl_generics ::core::hash::Hash for #ty #ty_generics #where_clause {
 			fn hash<__H: ::core::hash::Hasher>(&self, state: &mut __H) {
 				self.#data.hash(state);
@@ -126,6 +114,12 @@ pub fn expand_fixed_bytes(input: DeriveInput) -> TokenStream {
 
 			fn deref(&self) -> &Self::Target {
 				&self.#data
+			}
+		}
+
+		impl #impl_generics ::core::ops::DerefMut for #ty #ty_generics #where_clause {
+			fn deref_mut(&mut self) -> &mut Self::Target {
+				&mut self.#data
 			}
 		}
 	});

--- a/derive/tests/fixed_bytes.rs
+++ b/derive/tests/fixed_bytes.rs
@@ -39,11 +39,11 @@ macro_rules! test_derive_traits {
 		assert_eq!(s, s2);
 
 		// AsRef
-		assert_eq!(s.as_ref() as &[u8], &a[..]);
+		assert_eq!(s.as_ref(), &a[..]);
 
 		// AsMut
 		let mut s2 = s.clone();
-		(s2.as_mut() as &mut [u8])[2] = 2;
+		s2.as_mut()[2] = 2;
 		assert_eq!(s2, $x::from([1, 2, 2, 4]));
 
 		// Clone


### PR DESCRIPTION
This PR adds `DerefMut` implementation to `FixedBytes` derive macro to allow mutable access to the inner type and also removes `AsRef` and `AsMut` to the inner type that prevent type coercion.