### PR TITLE
fix: Set Deref::Target to inner for FixedBytes

### DIFF
--- a/derive/src/fixed_bytes.rs
+++ b/derive/src/fixed_bytes.rs
@@ -110,7 +110,7 @@ pub fn expand_fixed_bytes(input: DeriveInput) -> TokenStream {
 		}
 
 		impl #impl_generics ::core::ops::Deref for #ty #ty_generics #where_clause {
-			type Target = [u8];
+			type Target = #inner;
 
 			fn deref(&self) -> &Self::Target {
 				&self.#data


### PR DESCRIPTION
This PR makes the `Deref::Target` point to the inner type with the `FixedBytes` derive macro.